### PR TITLE
fix(header): Adjust logo position and size to avoid overlapping

### DIFF
--- a/global-top.vue
+++ b/global-top.vue
@@ -2,9 +2,9 @@
   <header
     style="
       position: fixed;
-      top: 1rem;
-      right: 2rem;
-      width: 200px;
+      top: 0.5rem;
+      right: 1rem;
+      width: 180px;
       opacity: 0.8;
       pointer-events: none;
       z-index: 9999;


### PR DESCRIPTION
## Description

Logo is crossing the header boundaries. This PR fixes the positioning make sure the logo is inside the header and avoid any overlaps.

Before:
<img width="720" height="823" alt="image" src="https://github.com/user-attachments/assets/3141c014-0731-40ef-bb84-f27ef6aaddd4" />

After:
<img width="706" height="826" alt="image" src="https://github.com/user-attachments/assets/dd7ca333-5479-4667-bc37-35509bae8546" />


## Testing

Tested locally

